### PR TITLE
Modified the Vector2  notEquals function to avoid a compiler error (V…

### DIFF
--- a/hxmath/math/Vector2.hx
+++ b/hxmath/math/Vector2.hx
@@ -260,7 +260,7 @@ abstract Vector2(Vector2Type) from Vector2Type to Vector2Type
     @:op(A != B)
     public static inline function notEquals(a:Vector2, b:Vector2):Bool
     {
-        return !(a == b);
+        return !equals(a, b);
     }
     
     /**


### PR DESCRIPTION
I had this error when using the Vector2 class from hxmath:
```
(Vector2.hx:263: characters 17-23 : Recursive operator method)
```

I suppose something in the Haxe compiler changed, and the fact that you use !(a == b) probably makes the notEquals function try to call itself if the compiler tries to take a shortcut, so I replaced it by a manual call to equals.

I suppose the same problem could happen in other places of the code though.