### PR TITLE
Add Heaps Math Structures

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ var pointBCast:Vector2 = new flash.geom.Point(2.0, 1.0);
 trace(pointACast * pointBCast);
 ```
 
-Not using OpenFL? hxmath can run without it, falling back on its default inner types.
+Using Heaps? Adding `-D HXMATH_USE_HEAPS_STRUCTURES` to your build parameters to use Heaps math types with hxmath instead.
+
+Not using either? hxmath can run without them, falling back on its default inner types.
 
 ### 2D and 3D math
 Both affine and linear structures:

--- a/hxmath/math/IntVector2.hx
+++ b/hxmath/math/IntVector2.hx
@@ -20,11 +20,17 @@ class IntVector2Default
     }
 }
 
+#if HXMATH_USE_HEAPS_STRUCTURES
+typedef IntVector2Type = h2d.col.IPoint;
+#else
+typedef IntVector2Type = IntVector2Default;
+#end
+
 /**
  * A 2D vector with integer values. Used primarily for indexing into 2D grids.
  */
 @:forward(x, y)
-abstract IntVector2(IntVector2Default) from IntVector2Default to IntVector2Default
+abstract IntVector2(IntVector2Type) from IntVector2Type to IntVector2Type
 {
     // The number of elements in this structure
     public static inline var elementCount:Int = 2;
@@ -55,7 +61,11 @@ abstract IntVector2(IntVector2Default) from IntVector2Default to IntVector2Defau
      */
     public function new(x:Int, y:Int)
     {
+        #if HXMATH_USE_HEAPS_STRUCTURES
+        this = new h2d.col.IPoint(x, y);
+        #else
         this = new IntVector2Default(x, y);
+        #end
     }
     
     /**

--- a/hxmath/math/Vector2.hx
+++ b/hxmath/math/Vector2.hx
@@ -28,6 +28,8 @@ class Vector2Default
 
 #if HXMATH_USE_OPENFL_STRUCTURES
 typedef Vector2Type = flash.geom.Point;
+#elseif HXMATH_USE_HEAPS_STRUCTURES
+typedef Vector2Type = h2d.col.Point;
 #else
 typedef Vector2Type = Vector2Default;
 #end
@@ -78,6 +80,8 @@ abstract Vector2(Vector2Type) from Vector2Type to Vector2Type
     {
         #if HXMATH_USE_OPENFL_STRUCTURES
         this = new flash.geom.Point(x, y);
+        #elseif HXMATH_USE_HEAPS_STRUCTURES
+        this = new h2d.col.Point(x, y);
         #else
         this = new Vector2Default(x, y);
         #end

--- a/hxmath/math/Vector3.hx
+++ b/hxmath/math/Vector3.hx
@@ -29,7 +29,11 @@ class Vector3Default
     }
 }
 
+#if HXMATH_USE_HEAPS_STRUCTURES
+typedef Vector3Type = h3d.col.Point;
+#else
 typedef Vector3Type = Vector3Default;
+#end
 
 /**
  * A 3D vector.
@@ -67,7 +71,11 @@ abstract Vector3(Vector3Type) from Vector3Type to Vector3Type
      */
     public inline function new(x:Float, y:Float, z:Float)
     {
+        #if HXMATH_USE_HEAPS_STRUCTURES
+        this = new h3d.col.Point(x, y, z);
+        #else
         this = new Vector3Default(x, y, z);
+        #end
     }
     
     /**

--- a/hxmath/math/Vector4.hx
+++ b/hxmath/math/Vector4.hx
@@ -34,6 +34,8 @@ class Vector4Default
 
 #if HXMATH_USE_OPENFL_STRUCTURES
 typedef Vector4Type = flash.geom.Vector3D;
+#elseif HXMATH_USE_HEAPS_STRUCTURES
+typedef Vector4Type = h3d.Vector;
 #else
 typedef Vector4Type = Vector4Default;
 #end
@@ -80,6 +82,8 @@ abstract Vector4(Vector4Type) from Vector4Type to Vector4Type
     {
         #if HXMATH_USE_OPENFL_STRUCTURES
         this = new flash.geom.Vector3D(x, y, z, w);
+        #elseif HXMATH_USE_HEAPS_STRUCTURES
+        this = new h3d.Vector(x, y, z, w);
         #else
         this = new Vector4Default(x, y, z, w);
         #end


### PR DESCRIPTION
(Copy of #54 from a different branch)

Just thought I'd add in the ability to use [Heaps](https://heaps.io/)' math types with this lib's vector classes. I didn't add in Heaps' Matrix class (I didn't feel confident enough with matrices to add it in properly) but that's also a possibility if wanted 😁