### PR TITLE
Vector2 Additions

### DIFF
--- a/hxmath/math/Vector2.hx
+++ b/hxmath/math/Vector2.hx
@@ -51,13 +51,13 @@ abstract Vector2(Vector2Type) from Vector2Type to Vector2Type
     public static var yAxis(get, never):Vector2;
     
     // Magnitude
-    public var length(get, never):Float;
+    public var length(get, set):Float;
     
     // Vector dotted with itself
     public var lengthSq(get, never):Float;
     
-    // The angle between this vector and the X axis
-    public var angle(get, never):Float;
+    // The angle between this vector and the X axis (in radians)
+    public var angle(get, set):Float;
     
     // The normalized vector
     public var normal(get, never):Vector2;
@@ -734,14 +734,12 @@ abstract Vector2(Vector2Type) from Vector2Type to Vector2Type
      * @param pivot     The pivot point to rotate around.
      * @return          The modified object.
      */
-    public inline function rotate(angle:Float, pivot:Vector2):Vector2
+    public inline function rotate(angle:Float, ?pivot:Vector2):Vector2
     {
         var self:Vector2 = this;
         
-        var cos = Math.cos(angle);
-        var sin = Math.sin(angle);
-        var dx = self.x - pivot.x;
-        var dy = self.y - pivot.y;
+        var dx = pivot == null ? self.x : self.x - pivot.x;
+        var dy = pivot == null ? self.y : self.y - pivot.y;
         
         self.x = dx * Math.cos(angle) - dy * Math.sin(angle);
         self.y = dx * Math.sin(angle) + dy * Math.cos(angle);
@@ -838,6 +836,21 @@ abstract Vector2(Vector2Type) from Vector2Type to Vector2Type
         var self:Vector2 = this;
         return self.clone()
             .rotateRight();
+    }
+
+    private inline function set_length(v:Float):Float
+    {
+        var self:Vector2 = this;
+        self.normalizeTo(v);
+        return v;
+    }
+
+    private inline function set_angle(v:Float):Float
+    {
+        var self:Vector2 = this;
+        var len = length;
+		self.set(len * Math.cos(v), len * Math.sin(v));
+		return v;
     }
 }
 

--- a/hxmath/math/Vector2.hx
+++ b/hxmath/math/Vector2.hx
@@ -51,7 +51,7 @@ abstract Vector2(Vector2Type) from Vector2Type to Vector2Type
     public static var yAxis(get, never):Vector2;
     
     // Magnitude
-    public var length(get, set):Float;
+    public var length(get, never):Float;
     
     // Vector dotted with itself
     public var lengthSq(get, never):Float;
@@ -740,8 +740,14 @@ abstract Vector2(Vector2Type) from Vector2Type to Vector2Type
         
         var cos = Math.cos(angle);
         var sin = Math.sin(angle);
-        var dx = pivot == null ? self.x : self.x - pivot.x;
-        var dy = pivot == null ? self.y : self.y - pivot.y;
+        var dx = self.x;
+        var dy = self.y;
+
+        if (pivot != null)
+        {
+            dx = self.x - pivot.x;
+            dy = self.y - pivot.y;
+        }
         
         self.x = dx * cos - dy * sin;
         self.y = dx * sin + dy * cos;
@@ -840,19 +846,12 @@ abstract Vector2(Vector2Type) from Vector2Type to Vector2Type
             .rotateRight();
     }
 
-    private inline function set_length(v:Float):Float
-    {
-        var self:Vector2 = this;
-        self.normalizeTo(v);
-        return v;
-    }
-
-    private inline function set_angle(v:Float):Float
+    private inline function set_angle(angle:Float):Float
     {
         var self:Vector2 = this;
         var len = length;
-		self.set(len * Math.cos(v), len * Math.sin(v));
-		return v;
+        self.set(len * Math.cos(angle), len * Math.sin(angle));
+        return angle;
     }
 }
 

--- a/hxmath/math/Vector2.hx
+++ b/hxmath/math/Vector2.hx
@@ -738,11 +738,13 @@ abstract Vector2(Vector2Type) from Vector2Type to Vector2Type
     {
         var self:Vector2 = this;
         
+        var cos = Math.cos(angle);
+        var sin = Math.sin(angle);
         var dx = pivot == null ? self.x : self.x - pivot.x;
         var dy = pivot == null ? self.y : self.y - pivot.y;
         
-        self.x = dx * Math.cos(angle) - dy * Math.sin(angle);
-        self.y = dx * Math.sin(angle) + dy * Math.cos(angle);
+        self.x = dx * cos - dy * sin;
+        self.y = dx * sin + dy * cos;
         
         return self;
     }

--- a/hxmath/math/Vector2.hx
+++ b/hxmath/math/Vector2.hx
@@ -730,8 +730,8 @@ abstract Vector2(Vector2Type) from Vector2Type to Vector2Type
     {
         var self:Vector2 = this;
         
-        var cos = Math.cos(angle);
-        var sin = Math.sin(angle);
+        var cosAngle = Math.cos(angle);
+        var sinAngle = Math.sin(angle);
         var dx = self.x;
         var dy = self.y;
 
@@ -741,8 +741,8 @@ abstract Vector2(Vector2Type) from Vector2Type to Vector2Type
             dy = self.y - pivot.y;
         }
         
-        self.x = dx * cos - dy * sin;
-        self.y = dx * sin + dy * cos;
+        self.x = dx * cosAngle - dy * sinAngle;
+        self.y = dx * sinAngle + dy * cosAngle;
         
         return self;
     }

--- a/test/Test2D.hx
+++ b/test/Test2D.hx
@@ -167,4 +167,17 @@ class Test2D extends MathTestCase
             assertEquals(-u.y, v.y);
         }
     }
+
+    public function testSetVectorAngle()
+    {
+        for (i in 0...10)
+        {
+            var v = randomVector2();
+            var a = randomFloat();
+
+            v.angle = a;
+
+            assertApproxEquals(a, v.angle);
+        }
+    }
 }

--- a/test/Test2D.hx
+++ b/test/Test2D.hx
@@ -204,10 +204,9 @@ class Test2D extends MathTestCase
 
     public function testSetVectorAngle()
     {
-        // Get a random Vector2
-        var v = randomVector2();
-
+        var v = new Vector2(1,0);
         var iterations = 8;
+        
         for (i in 0...iterations)
         {
             // Get incremental radian based on number of iterations

--- a/test/Test2D.hx
+++ b/test/Test2D.hx
@@ -1,5 +1,6 @@
 package test;
 
+import hxmath.math.MathUtil;
 import haxe.ds.Vector;
 import hxmath.math.IntVector2;
 import hxmath.math.Matrix2x2;
@@ -170,14 +171,22 @@ class Test2D extends MathTestCase
 
     public function testSetVectorAngle()
     {
-        for (i in 0...10)
-        {
-            var v = randomVector2();
-            var a = randomFloat();
+        // Get a random Vector2
+        var v = randomVector2();
 
+        var iterations = 8;
+        for (i in 0...iterations)
+        {
+            // Get incremental radian based on number of iterations
+            var a = (2 * Math.PI) * (i / iterations); 
+            
+            // Set vector2's angle
             v.angle = a;
 
-            assertApproxEquals(a, v.angle);
+            // Wrap the the vector's angle output, as Math.atan2 (used in Vector2.angle) may return a negative value
+            var va = MathUtil.wrap(v.angle, 2 * Math.PI);
+            
+            assertApproxEquals(a, va);
         }
     }
 }


### PR DESCRIPTION
This PR makes a couple of changes to `Vector2`:

* adds setter for the `angle` field
* makes the `pivot` parameter optional in `rotate()` method
* removes extra `cos` and `sin` calls in `rotate()` method