### PR TITLE
Move type definitions to single file

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ var pointBCast:Vector2 = new flash.geom.Point(2.0, 1.0);
 trace(pointACast * pointBCast);
 ```
 
-Not using OpenFL? hxmath can run without it, falling back on its default inner types.
+Using Heaps? Adding `-D HXMATH_USE_HEAPS_STRUCTURES` to your build parameters to use Heaps math types with hxmath instead.
+
+Not using either? hxmath can run without them, falling back on its default inner types or define them manually by overriding `hxmath.math.MathTypes`.
 
 ### 2D and 3D math
 Both affine and linear structures:

--- a/hxmath/math/IntVector2.hx
+++ b/hxmath/math/IntVector2.hx
@@ -1,5 +1,7 @@
 package hxmath.math;
 
+import hxmath.math.MathTypes;
+
 /**
  * The default underlying type.
  */
@@ -24,7 +26,7 @@ class IntVector2Default
  * A 2D vector with integer values. Used primarily for indexing into 2D grids.
  */
 @:forward(x, y)
-abstract IntVector2(IntVector2Default) from IntVector2Default to IntVector2Default
+abstract IntVector2(IntVector2Type) from IntVector2Type to IntVector2Type
 {
     // The number of elements in this structure
     public static inline var elementCount:Int = 2;
@@ -55,7 +57,7 @@ abstract IntVector2(IntVector2Default) from IntVector2Default to IntVector2Defau
      */
     public function new(x:Int, y:Int)
     {
-        this = new IntVector2Default(x, y);
+        this = new IntVector2Type(x, y);
     }
     
     /**

--- a/hxmath/math/MathTypes.hx
+++ b/hxmath/math/MathTypes.hx
@@ -1,0 +1,163 @@
+package hxmath.math;
+
+// This class provides underlying types used by HxMath.
+// It's possible to override those types by creating `hxmath/math/MathTypes.hx` file
+// in your project and defining all types with your own.
+#if HXMATH_USE_OPENFL_STRUCTURES
+typedef IntVector2Type = hxmath.math.IntVector2.IntVector2Default;
+typedef Matrix2x2Type = hxmath.math.Matrix2x2.Matrix2x2Default;
+typedef Matrix3x2Type = flash.geom.Matrix;
+typedef Matrix3x3Type = hxmath.math.Matrix3x3.Matrix3x3Default;
+typedef Matrix4x4Type = hxmath.math.Matrix4x4.Matrix4x4Default;
+typedef QuaternionType = hxmath.math.Quaternion.QuaternionDefault;
+typedef Vector2Type = flash.geom.Point;
+typedef Vector3Type = hxmath.math.Vector3.Vector3Default;
+typedef Vector4Type = flash.geom.Vector3D;
+#elseif HXMATH_USE_HEAPS_STRUCTURES
+
+typedef IntVector2Type = h2d.col.IPoint;
+typedef Vector2Type = h2d.col.Point;
+typedef Vector3Type = h3d.col.Point;
+typedef Vector4Type = h3d.Vector;
+
+typedef Matrix2x2Type = hxmath.math.Matrix2x2.Matrix2x2Default;
+typedef Matrix3x3Type = hxmath.math.Matrix3x3.Matrix3x3Default;
+
+// Heaps 3x2 matrix uses [x, y] as translation name instead of [tx, ty].
+@:forward
+abstract Matrix3x2Type(h2d.col.Matrix) from h2d.col.Matrix to h2d.col.Matrix
+{
+  
+  public inline function new(a:Float, b:Float, c:Float, d:Float, tx:Float, ty:Float)
+  {
+    this = new h2d.col.Matrix();
+    this.a = a;
+    this.b = b;
+    this.c = c;
+    this.d = d;
+    this.x = tx;
+    this.y = ty;
+  }
+  
+  public var tx(get, set):Float;
+  private inline function get_tx():Float return this.x;
+  private inline function set_tx(v:Float):Float return this.x = v;
+  
+  public var ty(get, set):Float;
+  private inline function get_ty():Float return this.y;
+  private inline function set_ty(v:Float):Float return this.y = v;
+}
+
+// Heaps uses different naming convention for matrix with following mapping:
+// [      hmath       ] -> [      heaps       ]
+// [m00, m10, m20, m30] -> [_11, _12, _13, _14]
+// [m01, m11, m21, m31] -> [_21, _22, _23, _24]
+// [m02, m12, m22, m32] -> [_31, _32, _33, _34]
+// [m03, m13, m23, m33] -> [_41, _42, _43, _44]
+@:forward
+abstract Matrix4x4Type(h3d.Matrix) from h3d.Matrix to h3d.Matrix
+{
+  public inline function new(m00:Float, m10:Float, m20:Float, m30:Float,
+        m01:Float, m11:Float, m21:Float, m31:Float,
+        m02:Float, m12:Float, m22:Float, m32:Float,
+        m03:Float, m13:Float, m23:Float, m33:Float)
+  {
+    this = new h3d.Matrix();
+    this._11 = m00; this._12 = m10; this._13 = m20; this._14 = m30;
+    this._21 = m01; this._22 = m11; this._23 = m21; this._24 = m31;
+    this._31 = m02; this._32 = m12; this._33 = m22; this._34 = m32;
+    this._41 = m03; this._42 = m13; this._43 = m23; this._44 = m33;
+  }
+  
+  public var m00(get, set):Float;
+  private inline function get_m00():Float return this._11;
+  private inline function set_m00(v:Float):Float return this._11 = v;
+  
+  public var m10(get, set):Float;
+  private inline function get_m10():Float return this._12;
+  private inline function set_m10(v:Float):Float return this._12 = v;
+  
+  public var m20(get, set):Float;
+  private inline function get_m20():Float return this._13;
+  private inline function set_m20(v:Float):Float return this._13 = v;
+  
+  public var m30(get, set):Float;
+  private inline function get_m30():Float return this._14;
+  private inline function set_m30(v:Float):Float return this._14 = v;
+  
+  public var m01(get, set):Float;
+  private inline function get_m01():Float return this._21;
+  private inline function set_m01(v:Float):Float return this._21 = v;
+  
+  public var m11(get, set):Float;
+  private inline function get_m11():Float return this._22;
+  private inline function set_m11(v:Float):Float return this._22 = v;
+  
+  public var m21(get, set):Float;
+  private inline function get_m21():Float return this._23;
+  private inline function set_m21(v:Float):Float return this._23 = v;
+  
+  public var m31(get, set):Float;
+  private inline function get_m31():Float return this._24;
+  private inline function set_m31(v:Float):Float return this._24 = v;
+  
+  public var m02(get, set):Float;
+  private inline function get_m02():Float return this._31;
+  private inline function set_m02(v:Float):Float return this._31 = v;
+  
+  public var m12(get, set):Float;
+  private inline function get_m12():Float return this._32;
+  private inline function set_m12(v:Float):Float return this._32 = v;
+  
+  public var m22(get, set):Float;
+  private inline function get_m22():Float return this._33;
+  private inline function set_m22(v:Float):Float return this._33 = v;
+  
+  public var m32(get, set):Float;
+  private inline function get_m32():Float return this._34;
+  private inline function set_m32(v:Float):Float return this._34 = v;
+  
+  public var m03(get, set):Float;
+  private inline function get_m03():Float return this._41;
+  private inline function set_m03(v:Float):Float return this._41 = v;
+  
+  public var m13(get, set):Float;
+  private inline function get_m13():Float return this._42;
+  private inline function set_m13(v:Float):Float return this._42 = v;
+  
+  public var m23(get, set):Float;
+  private inline function get_m23():Float return this._43;
+  private inline function set_m23(v:Float):Float return this._43 = v;
+  
+  public var m33(get, set):Float;
+  private inline function get_m33():Float return this._44;
+  private inline function set_m33(v:Float):Float return this._44 = v;
+}
+
+// Heaps Quaternion use `w` instead of `s` to store scalar.
+@:forward
+abstract QuaternionType(h3d.Quat) from h3d.Quat to h3d.Quat
+{
+  
+  public inline function new(s:Float, x:Float, y:Float, z:Float)
+  {
+    this = new h3d.Quat(x, y, z, s);
+  }
+  
+  public var s(get, set):Float;
+  private inline function get_s():Float return this.w;
+  private inline function set_s(v:Float):Float return this.w = v;
+  
+}
+
+#else
+typedef IntVector2Type = hxmath.math.IntVector2.IntVector2Default;
+typedef Matrix2x2Type = hxmath.math.Matrix2x2.Matrix2x2Default;
+typedef Matrix3x2Type = hxmath.math.Matrix3x2.Matrix3x2Default;
+typedef Matrix3x3Type = hxmath.math.Matrix3x3.Matrix3x3Default;
+typedef Matrix4x4Type = hxmath.math.Matrix4x4.Matrix4x4Default;
+typedef QuaternionType = hxmath.math.Quaternion.QuaternionDefault;
+typedef Vector2Type = hxmath.math.Vector2.Vector2Default;
+typedef Vector3Type = hxmath.math.Vector3.Vector3Default;
+typedef Vector4Type = hxmath.math.Vector4.Vector4Default;
+#end

--- a/hxmath/math/MathTypes.hx
+++ b/hxmath/math/MathTypes.hx
@@ -3,7 +3,11 @@ package hxmath.math;
 // This class provides underlying types used by HxMath.
 // It's possible to override those types by creating `hxmath/math/MathTypes.hx` file
 // in your project and defining all types with your own.
+
 #if HXMATH_USE_OPENFL_STRUCTURES
+/**
+ * OpenFL/Flash types
+ */
 typedef IntVector2Type = hxmath.math.IntVector2.IntVector2Default;
 typedef Matrix2x2Type = hxmath.math.Matrix2x2.Matrix2x2Default;
 typedef Matrix3x2Type = flash.geom.Matrix;
@@ -13,8 +17,11 @@ typedef QuaternionType = hxmath.math.Quaternion.QuaternionDefault;
 typedef Vector2Type = flash.geom.Point;
 typedef Vector3Type = hxmath.math.Vector3.Vector3Default;
 typedef Vector4Type = flash.geom.Vector3D;
-#elseif HXMATH_USE_HEAPS_STRUCTURES
 
+#elseif HXMATH_USE_HEAPS_STRUCTURES
+/**
+ * Heaps types
+ */
 typedef IntVector2Type = h2d.col.IPoint;
 typedef Vector2Type = h2d.col.Point;
 typedef Vector3Type = h3d.col.Point;
@@ -27,29 +34,29 @@ typedef Matrix3x3Type = hxmath.math.Matrix3x3.Matrix3x3Default;
 @:forward
 abstract Matrix3x2Type(h2d.col.Matrix) from h2d.col.Matrix to h2d.col.Matrix
 {
-  
-  public inline function new(a:Float, b:Float, c:Float, d:Float, tx:Float, ty:Float)
-  {
-    this = new h2d.col.Matrix();
-    this.a = a;
-    this.b = b;
-    this.c = c;
-    this.d = d;
-    this.x = tx;
-    this.y = ty;
-  }
-  
-  public var tx(get, set):Float;
-  private inline function get_tx():Float return this.x;
-  private inline function set_tx(v:Float):Float return this.x = v;
-  
-  public var ty(get, set):Float;
-  private inline function get_ty():Float return this.y;
-  private inline function set_ty(v:Float):Float return this.y = v;
+
+    public inline function new(a:Float, b:Float, c:Float, d:Float, tx:Float, ty:Float)
+    {
+        this = new h2d.col.Matrix();
+        this.a = a;
+        this.b = b;
+        this.c = c;
+        this.d = d;
+        this.x = tx;
+        this.y = ty;
+    }
+
+    public var tx(get, set):Float;
+    private inline function get_tx():Float return this.x;
+    private inline function set_tx(v:Float):Float return this.x = v;
+
+    public var ty(get, set):Float;
+    private inline function get_ty():Float return this.y;
+    private inline function set_ty(v:Float):Float return this.y = v;
 }
 
 // Heaps uses different naming convention for matrix with following mapping:
-// [      hmath       ] -> [      heaps       ]
+// [      hxmath      ] -> [      heaps       ]
 // [m00, m10, m20, m30] -> [_11, _12, _13, _14]
 // [m01, m11, m21, m31] -> [_21, _22, _23, _24]
 // [m02, m12, m22, m32] -> [_31, _32, _33, _34]
@@ -57,100 +64,104 @@ abstract Matrix3x2Type(h2d.col.Matrix) from h2d.col.Matrix to h2d.col.Matrix
 @:forward
 abstract Matrix4x4Type(h3d.Matrix) from h3d.Matrix to h3d.Matrix
 {
-  public inline function new(m00:Float, m10:Float, m20:Float, m30:Float,
+    public inline function new(
+        m00:Float, m10:Float, m20:Float, m30:Float,
         m01:Float, m11:Float, m21:Float, m31:Float,
         m02:Float, m12:Float, m22:Float, m32:Float,
         m03:Float, m13:Float, m23:Float, m33:Float)
-  {
-    this = new h3d.Matrix();
-    this._11 = m00; this._12 = m10; this._13 = m20; this._14 = m30;
-    this._21 = m01; this._22 = m11; this._23 = m21; this._24 = m31;
-    this._31 = m02; this._32 = m12; this._33 = m22; this._34 = m32;
-    this._41 = m03; this._42 = m13; this._43 = m23; this._44 = m33;
-  }
-  
-  public var m00(get, set):Float;
-  private inline function get_m00():Float return this._11;
-  private inline function set_m00(v:Float):Float return this._11 = v;
-  
-  public var m10(get, set):Float;
-  private inline function get_m10():Float return this._12;
-  private inline function set_m10(v:Float):Float return this._12 = v;
-  
-  public var m20(get, set):Float;
-  private inline function get_m20():Float return this._13;
-  private inline function set_m20(v:Float):Float return this._13 = v;
-  
-  public var m30(get, set):Float;
-  private inline function get_m30():Float return this._14;
-  private inline function set_m30(v:Float):Float return this._14 = v;
-  
-  public var m01(get, set):Float;
-  private inline function get_m01():Float return this._21;
-  private inline function set_m01(v:Float):Float return this._21 = v;
-  
-  public var m11(get, set):Float;
-  private inline function get_m11():Float return this._22;
-  private inline function set_m11(v:Float):Float return this._22 = v;
-  
-  public var m21(get, set):Float;
-  private inline function get_m21():Float return this._23;
-  private inline function set_m21(v:Float):Float return this._23 = v;
-  
-  public var m31(get, set):Float;
-  private inline function get_m31():Float return this._24;
-  private inline function set_m31(v:Float):Float return this._24 = v;
-  
-  public var m02(get, set):Float;
-  private inline function get_m02():Float return this._31;
-  private inline function set_m02(v:Float):Float return this._31 = v;
-  
-  public var m12(get, set):Float;
-  private inline function get_m12():Float return this._32;
-  private inline function set_m12(v:Float):Float return this._32 = v;
-  
-  public var m22(get, set):Float;
-  private inline function get_m22():Float return this._33;
-  private inline function set_m22(v:Float):Float return this._33 = v;
-  
-  public var m32(get, set):Float;
-  private inline function get_m32():Float return this._34;
-  private inline function set_m32(v:Float):Float return this._34 = v;
-  
-  public var m03(get, set):Float;
-  private inline function get_m03():Float return this._41;
-  private inline function set_m03(v:Float):Float return this._41 = v;
-  
-  public var m13(get, set):Float;
-  private inline function get_m13():Float return this._42;
-  private inline function set_m13(v:Float):Float return this._42 = v;
-  
-  public var m23(get, set):Float;
-  private inline function get_m23():Float return this._43;
-  private inline function set_m23(v:Float):Float return this._43 = v;
-  
-  public var m33(get, set):Float;
-  private inline function get_m33():Float return this._44;
-  private inline function set_m33(v:Float):Float return this._44 = v;
+    {
+        this = new h3d.Matrix();
+        this._11 = m00; this._12 = m10; this._13 = m20; this._14 = m30;
+        this._21 = m01; this._22 = m11; this._23 = m21; this._24 = m31;
+        this._31 = m02; this._32 = m12; this._33 = m22; this._34 = m32;
+        this._41 = m03; this._42 = m13; this._43 = m23; this._44 = m33;
+    }
+
+    public var m00(get, set):Float;
+    private inline function get_m00():Float return this._11;
+    private inline function set_m00(v:Float):Float return this._11 = v;
+
+    public var m10(get, set):Float;
+    private inline function get_m10():Float return this._12;
+    private inline function set_m10(v:Float):Float return this._12 = v;
+
+    public var m20(get, set):Float;
+    private inline function get_m20():Float return this._13;
+    private inline function set_m20(v:Float):Float return this._13 = v;
+
+    public var m30(get, set):Float;
+    private inline function get_m30():Float return this._14;
+    private inline function set_m30(v:Float):Float return this._14 = v;
+
+    public var m01(get, set):Float;
+    private inline function get_m01():Float return this._21;
+    private inline function set_m01(v:Float):Float return this._21 = v;
+
+    public var m11(get, set):Float;
+    private inline function get_m11():Float return this._22;
+    private inline function set_m11(v:Float):Float return this._22 = v;
+
+    public var m21(get, set):Float;
+    private inline function get_m21():Float return this._23;
+    private inline function set_m21(v:Float):Float return this._23 = v;
+
+    public var m31(get, set):Float;
+    private inline function get_m31():Float return this._24;
+    private inline function set_m31(v:Float):Float return this._24 = v;
+
+    public var m02(get, set):Float;
+    private inline function get_m02():Float return this._31;
+    private inline function set_m02(v:Float):Float return this._31 = v;
+
+    public var m12(get, set):Float;
+    private inline function get_m12():Float return this._32;
+    private inline function set_m12(v:Float):Float return this._32 = v;
+
+    public var m22(get, set):Float;
+    private inline function get_m22():Float return this._33;
+    private inline function set_m22(v:Float):Float return this._33 = v;
+
+    public var m32(get, set):Float;
+    private inline function get_m32():Float return this._34;
+    private inline function set_m32(v:Float):Float return this._34 = v;
+
+    public var m03(get, set):Float;
+    private inline function get_m03():Float return this._41;
+    private inline function set_m03(v:Float):Float return this._41 = v;
+
+    public var m13(get, set):Float;
+    private inline function get_m13():Float return this._42;
+    private inline function set_m13(v:Float):Float return this._42 = v;
+
+    public var m23(get, set):Float;
+    private inline function get_m23():Float return this._43;
+    private inline function set_m23(v:Float):Float return this._43 = v;
+
+    public var m33(get, set):Float;
+    private inline function get_m33():Float return this._44;
+    private inline function set_m33(v:Float):Float return this._44 = v;
 }
 
-// Heaps Quaternion use `w` instead of `s` to store scalar.
+// Heaps Quaternion uses `w` instead of `s` to store scalar.
 @:forward
 abstract QuaternionType(h3d.Quat) from h3d.Quat to h3d.Quat
 {
-  
-  public inline function new(s:Float, x:Float, y:Float, z:Float)
-  {
-    this = new h3d.Quat(x, y, z, s);
-  }
-  
-  public var s(get, set):Float;
-  private inline function get_s():Float return this.w;
-  private inline function set_s(v:Float):Float return this.w = v;
-  
+
+    public inline function new(s:Float, x:Float, y:Float, z:Float)
+    {
+        this = new h3d.Quat(x, y, z, s);
+    }
+
+    public var s(get, set):Float;
+    private inline function get_s():Float return this.w;
+    private inline function set_s(v:Float):Float return this.w = v;
+
 }
 
 #else
+/**
+ * Default built-in types.
+ */
 typedef IntVector2Type = hxmath.math.IntVector2.IntVector2Default;
 typedef Matrix2x2Type = hxmath.math.Matrix2x2.Matrix2x2Default;
 typedef Matrix3x2Type = hxmath.math.Matrix3x2.Matrix3x2Default;

--- a/hxmath/math/Matrix2x2.hx
+++ b/hxmath/math/Matrix2x2.hx
@@ -1,5 +1,7 @@
 package hxmath.math;
 
+import hxmath.math.MathTypes;
+
 // Note: All notation is column-major, e.g. m10 is the top element of the 2nd column
 typedef Matrix2x2Shape = 
 {
@@ -40,8 +42,6 @@ class Matrix2x2Default
     }
 }
 
-typedef Matrix2x2Type = Matrix2x2Default;
-
 /**
  * 2x2 matrix for linear operations defined over a shape matching the 2x2 linear sub-matrix in flash.geom.Matrix.
  */
@@ -77,7 +77,7 @@ abstract Matrix2x2(Matrix2x2Type) from Matrix2x2Type to Matrix2x2Type
      */
     public inline function new(a:Float, b:Float, c:Float, d:Float) 
     {
-        this = new Matrix2x2Default(a, b, c, d);
+        this = new Matrix2x2Type(a, b, c, d);
     }
     
     /**

--- a/hxmath/math/Matrix3x2.hx
+++ b/hxmath/math/Matrix3x2.hx
@@ -1,5 +1,7 @@
 package hxmath.math;
 
+import hxmath.math.MathTypes;
+
 typedef Matrix3x2Shape = 
 {
     // m00
@@ -49,12 +51,6 @@ class Matrix3x2Default
     }
 }
 
-#if HXMATH_USE_OPENFL_STRUCTURES
-typedef Matrix3x2Type = flash.geom.Matrix;
-#else
-typedef Matrix3x2Type = Matrix3x2Default;
-#end
-
 /**
  * 3x2 matrix for mixed affine/linear operations defined over a shape matching flash.geom.Matrix.
  */
@@ -93,11 +89,7 @@ abstract Matrix3x2(Matrix3x2Type) from Matrix3x2Type to Matrix3x2Type
      */
     public inline function new(a:Float, b:Float, c:Float, d:Float, tx:Float, ty:Float)
     {
-        #if HXMATH_USE_OPENFL_STRUCTURES
-        this = new flash.geom.Matrix(a, b, c, d, tx, ty);
-        #else
-        this = new Matrix3x2Default(a, b, c, d, tx, ty);
-        #end
+        this = new Matrix3x2Type(a, b, c, d, tx, ty);
     }
     
     /**

--- a/hxmath/math/Matrix3x3.hx
+++ b/hxmath/math/Matrix3x3.hx
@@ -1,5 +1,7 @@
 package hxmath.math;
 
+import hxmath.math.MathTypes;
+
 // Note: All notation is column-major, e.g. m10 is the top element of the 2nd column
 typedef Matrix3x3Shape = 
 {
@@ -57,8 +59,6 @@ class Matrix3x3Default
     }
 }
 
-typedef Matrix3x3Type = Matrix3x3Default;
-
 /**
  * 3x3 matrix for linear transformations in 3D.
  */
@@ -101,7 +101,7 @@ abstract Matrix3x3(Matrix3x3Type) from Matrix3x3Type to Matrix3x3Type
         m01:Float, m11:Float, m21:Float,
         m02:Float, m12:Float, m22:Float)
     {
-        this = new Matrix3x3Default(
+        this = new Matrix3x3Type(
             m00, m10, m20,
             m01, m11, m21,
             m02, m12, m22);

--- a/hxmath/math/Matrix4x4.hx
+++ b/hxmath/math/Matrix4x4.hx
@@ -1,5 +1,7 @@
 package hxmath.math;
 
+import hxmath.math.MathTypes;
+
 // Note: All notation is column-major, e.g. m10 is the top element of the 2nd column
 typedef Matrix4x4Shape = 
 {
@@ -82,8 +84,6 @@ class Matrix4x4Default
     }
 }
 
-typedef Matrix4x4Type = Matrix4x4Default;
-
 /**
  * 4x4 matrix for homogenous/projection transformations in 3D.
  */
@@ -141,7 +141,7 @@ abstract Matrix4x4(Matrix4x4Type) from Matrix4x4Type to Matrix4x4Type
         m02:Float, m12:Float, m22:Float, m32:Float,
         m03:Float, m13:Float, m23:Float, m33:Float) 
     {
-        this = new Matrix4x4Default(
+        this = new Matrix4x4Type(
             m00, m10, m20, m30,
             m01, m11, m21, m31,
             m02, m12, m22, m32,

--- a/hxmath/math/Quaternion.hx
+++ b/hxmath/math/Quaternion.hx
@@ -1,5 +1,7 @@
 package hxmath.math;
 
+import hxmath.math.MathTypes;
+
 typedef QuaternionShape = 
 {
     public var s:Float;
@@ -31,8 +33,6 @@ class QuaternionDefault
         return '[$s, ($x, $y, $z)]';
     }
 }
-
-typedef QuaternionType = QuaternionDefault;
 
 /**
  * Quaternion for rotation in 3D.
@@ -71,7 +71,7 @@ abstract Quaternion(QuaternionType) from QuaternionType to QuaternionType
      */
     public inline function new(s:Float, x:Float, y:Float, z:Float) 
     {
-        this = new QuaternionDefault(s, x, y, z);
+        this = new QuaternionType(s, x, y, z);
     }
     
     /**

--- a/hxmath/math/Vector2.hx
+++ b/hxmath/math/Vector2.hx
@@ -1,5 +1,7 @@
 package hxmath.math;
 
+import hxmath.math.MathTypes;
+
 typedef Vector2Shape =
 {
     public var x:Float;
@@ -25,12 +27,6 @@ class Vector2Default
         return '($x, $y)';
     }
 }
-
-#if HXMATH_USE_OPENFL_STRUCTURES
-typedef Vector2Type = flash.geom.Point;
-#else
-typedef Vector2Type = Vector2Default;
-#end
 
 /**
  * A 2D vector.
@@ -76,11 +72,7 @@ abstract Vector2(Vector2Type) from Vector2Type to Vector2Type
      */
     public inline function new(x:Float, y:Float)
     {
-        #if HXMATH_USE_OPENFL_STRUCTURES
-        this = new flash.geom.Point(x, y);
-        #else
-        this = new Vector2Default(x, y);
-        #end
+        this = new Vector2Type(x, y);
     }
     
     /**

--- a/hxmath/math/Vector3.hx
+++ b/hxmath/math/Vector3.hx
@@ -1,5 +1,7 @@
 package hxmath.math;
 
+import hxmath.math.MathTypes;
+
 typedef Vector3Shape =
 {
     public var x:Float;
@@ -28,8 +30,6 @@ class Vector3Default
         return '($x, $y, $z)';
     }
 }
-
-typedef Vector3Type = Vector3Default;
 
 /**
  * A 3D vector.
@@ -67,7 +67,7 @@ abstract Vector3(Vector3Type) from Vector3Type to Vector3Type
      */
     public inline function new(x:Float, y:Float, z:Float)
     {
-        this = new Vector3Default(x, y, z);
+        this = new Vector3Type(x, y, z);
     }
     
     /**

--- a/hxmath/math/Vector4.hx
+++ b/hxmath/math/Vector4.hx
@@ -1,5 +1,7 @@
 package hxmath.math;
 
+import hxmath.math.MathTypes;
+
 typedef Vector4Shape =
 {
     public var x:Float;
@@ -31,12 +33,6 @@ class Vector4Default
         return '($x, $y, $z, $w)';
     }
 }
-
-#if HXMATH_USE_OPENFL_STRUCTURES
-typedef Vector4Type = flash.geom.Vector3D;
-#else
-typedef Vector4Type = Vector4Default;
-#end
 
 /**
  * A 4D vector (used with homogenous/projection matrices in 3D).
@@ -78,11 +74,7 @@ abstract Vector4(Vector4Type) from Vector4Type to Vector4Type
      */
     public inline function new(x:Float, y:Float, z:Float, w:Float)
     {
-        #if HXMATH_USE_OPENFL_STRUCTURES
-        this = new flash.geom.Vector3D(x, y, z, w);
-        #else
-        this = new Vector4Default(x, y, z, w);
-        #end
+        this = new Vector4Type(x, y, z, w);
     }
     
     /**


### PR DESCRIPTION
* Moved all `XType` defines to single file `MathTypes`.
* Also implemented Heaps integration along the way, superseding separate PR. (Matrices are added as well as Quaternion, Austin gave his consent on me taking over the integration implementation) I want me math types in me Heaps. :)

Heaps matrices use different naming conventions, and due to that abstracts are used. For 2d matrix `tx, ty` mapped to `x, y`. For 3D matrix Heaps convention is `_YX` with 1-indexing, while OFL/hxmath uses `mXY` with 0-indexing. Mapped accordingly. Lastly, Quaternions in Heaps store scalar in `w`, which was mapped to `s` respectively. 

Resolve #65 
Resolve #55