### PR TITLE
Inline default math type constructors

### DIFF
--- a/hxmath/math/IntVector2.hx
+++ b/hxmath/math/IntVector2.hx
@@ -10,7 +10,7 @@ class IntVector2Default
     public var x:Int;
     public var y:Int;
     
-    public function new(x:Int, y:Int)
+    public inline function new(x:Int, y:Int)
     {
         this.x = x;
         this.y = y;

--- a/hxmath/math/Matrix2x2.hx
+++ b/hxmath/math/Matrix2x2.hx
@@ -28,7 +28,7 @@ class Matrix2x2Default
     public var c:Float;
     public var d:Float;
     
-    public function new(a:Float, b:Float, c:Float, d:Float)
+    public inline function new(a:Float, b:Float, c:Float, d:Float)
     {
         this.a = a;
         this.b = b;

--- a/hxmath/math/Matrix3x2.hx
+++ b/hxmath/math/Matrix3x2.hx
@@ -35,7 +35,7 @@ class Matrix3x2Default
     public var tx:Float;
     public var ty:Float;
     
-    public function new(a:Float, b:Float, c:Float, d:Float, tx:Float, ty:Float)
+    public inline function new(a:Float, b:Float, c:Float, d:Float, tx:Float, ty:Float)
     {
         this.a = a;
         this.b = b;

--- a/hxmath/math/Matrix3x3.hx
+++ b/hxmath/math/Matrix3x3.hx
@@ -35,7 +35,7 @@ class Matrix3x3Default
     public var m21:Float;
     public var m22:Float;
     
-    public function new(
+    public inline function new(
         m00:Float, m10:Float, m20:Float,
         m01:Float, m11:Float, m21:Float,
         m02:Float, m12:Float, m22:Float)

--- a/hxmath/math/Matrix4x4.hx
+++ b/hxmath/math/Matrix4x4.hx
@@ -51,7 +51,7 @@ class Matrix4x4Default
     public var m32:Float;
     public var m33:Float;
     
-    public function new(
+    public inline function new(
         m00:Float, m10:Float, m20:Float, m30:Float,
         m01:Float, m11:Float, m21:Float, m31:Float,
         m02:Float, m12:Float, m22:Float, m32:Float,

--- a/hxmath/math/Quaternion.hx
+++ b/hxmath/math/Quaternion.hx
@@ -20,7 +20,7 @@ class QuaternionDefault
     public var y:Float;
     public var z:Float;
     
-    public function new(s:Float, x:Float, y:Float, z:Float)
+    public inline function new(s:Float, x:Float, y:Float, z:Float)
     {
         this.s = s;
         this.x = x;

--- a/hxmath/math/Vector2.hx
+++ b/hxmath/math/Vector2.hx
@@ -16,7 +16,7 @@ class Vector2Default
     public var x:Float;
     public var y:Float;
     
-    public function new(x:Float, y:Float)
+    public inline function new(x:Float, y:Float)
     {
         this.x = x;
         this.y = y;

--- a/hxmath/math/Vector3.hx
+++ b/hxmath/math/Vector3.hx
@@ -18,7 +18,7 @@ class Vector3Default
     public var y:Float;
     public var z:Float;
     
-    public function new(x:Float, y:Float, z:Float)
+    public inline function new(x:Float, y:Float, z:Float)
     {
         this.x = x;
         this.y = y;

--- a/hxmath/math/Vector4.hx
+++ b/hxmath/math/Vector4.hx
@@ -20,7 +20,7 @@ class Vector4Default
     public var z:Float;
     public var w:Float;
     
-    public function new(x:Float, y:Float, z:Float, w:Float)
+    public inline function new(x:Float, y:Float, z:Float, w:Float)
     {
         this.x = x;
         this.y = y;


### PR DESCRIPTION
This PR just adds `inline` to all the default math type constructors. This will allow the Haxe compiler to reduce allocations on local variables, which has huge performance implications for game projects that use lots of math functions every frame. 

As a test case, I used this branch on my physics library [echo](https://austineast.dev/echo/), which uses hxmath classes throughout its codebase. It nearly got rid of all my allocations, and drastically improved performance on Hashlink (over 2x!), which was previously getting hit pretty hard by garbage collection.

If you're interested, here is some more info on inlined constructors: https://haxe.org/manual/lf-inline-constructor.html