### PR TITLE
Fix `Vector2.rotate` not rotating around `pivot`

### DIFF
--- a/src/hxmath/math/Vector2.hx
+++ b/src/hxmath/math/Vector2.hx
@@ -741,8 +741,8 @@ abstract Vector2(Vector2Type) from Vector2Type to Vector2Type
             dy = self.y - pivot.y;
         }
         
-        self.x = dx * cosAngle - dy * sinAngle;
-        self.y = dx * sinAngle + dy * cosAngle;
+        self.x = dx * cosAngle - dy * sinAngle + pivot.x;
+        self.y = dx * sinAngle + dy * cosAngle + pivot.y;
         
         return self;
     }


### PR DESCRIPTION
The strategy is to subtract the pivot point, perform the rotation, and then add it back. The old code simply forgot step 3.